### PR TITLE
Proof-of-concept to configure JIRA link for SourceTree on macOS and Windows

### DIFF
--- a/clone.sh
+++ b/clone.sh
@@ -8,3 +8,12 @@
 set -e
 
 git-lfs clone --recursive $@
+
+case $(uname -s) in
+    CYGWIN_NT-*|MINGW??_NT*)
+        powershell "$KIT_PATH/lib/win/sourcetree_add_commit_link_text.ps1"
+        ;;
+    Darwin)
+        "$KIT_PATH/lib/osx/sourcetree_add_commit_link_text.sh"
+        ;;
+esac

--- a/lib/osx/sourcetree_add_commit_link_text.sh
+++ b/lib/osx/sourcetree_add_commit_link_text.sh
@@ -4,6 +4,9 @@ FILE=${1:-.git/sourcetreeconfig}
 
 KEY_NUMBER="0"
 
+DESC_KEY="commentURLParser$KEY_NUMBER.description"
+DESC_VALUE="Enterprise config for Git"
+
 TYPE_KEY="commentURLParser$KEY_NUMBER.type"
 TYPE_VALUE="0"
 
@@ -21,9 +24,10 @@ fi
 # Ensure to remove any regex / target entries.
 TEMP_FILE=$(mktemp)
 mv $FILE $TEMP_FILE
-grep -v "^commentURLParser$KEY_NUMBER\.\(regex\|target\)" $TEMP_FILE > $FILE
+grep -v "^commentURLParser$KEY_NUMBER\.\(description\|regex\|target\)" $TEMP_FILE > $FILE
 rm $TEMP_FILE
 
+echo "$DESC_KEY=$DESC_VALUE" >> $FILE
 echo "$TYPE_KEY=$TYPE_VALUE" >> $FILE
 echo "$REGEX_KEY=$REGEX_VALUE" >> $FILE
 echo "$TARGET_KEY=$TARGET_VALUE" >> $FILE

--- a/lib/osx/sourcetree_add_commit_link_text.sh
+++ b/lib/osx/sourcetree_add_commit_link_text.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+FILE=${1:-.git/sourcetreeconfig}
+
+KEY_NUMBER="0"
+
+TYPE_KEY="commentURLParser$KEY_NUMBER.type"
+TYPE_VALUE="0"
+
+REGEX_KEY="commentURLParser$KEY_NUMBER.regex"
+REGEX_VALUE=$(git config --global bugtraq.jira.logregex)
+
+TARGET_KEY="commentURLParser$KEY_NUMBER.target"
+TARGET_VALUE=$(git config --global bugtraq.jira.url | sed s,%BUGID%,\$1,)
+
+if grep -q $TYPE_KEY $FILE; then
+    echo "The comment parser URL type is already present and will not be modified."
+    exit 0
+fi
+
+# Ensure to remove any regex / target entries.
+mv $FILE $FILE.orig
+grep -v "^commentURLParser$KEY_NUMBER\.\(regex\|target\)" $FILE.orig > $FILE
+rm $FILE.orig
+
+echo "$TYPE_KEY=$TYPE_VALUE" >> $FILE
+echo "$REGEX_KEY=$REGEX_VALUE" >> $FILE
+echo "$TARGET_KEY=$TARGET_VALUE" >> $FILE

--- a/lib/osx/sourcetree_add_commit_link_text.sh
+++ b/lib/osx/sourcetree_add_commit_link_text.sh
@@ -19,9 +19,10 @@ if grep -q $TYPE_KEY $FILE; then
 fi
 
 # Ensure to remove any regex / target entries.
-mv $FILE $FILE.orig
-grep -v "^commentURLParser$KEY_NUMBER\.\(regex\|target\)" $FILE.orig > $FILE
-rm $FILE.orig
+TEMP_FILE=$(mktemp)
+mv $FILE $TEMP_FILE
+grep -v "^commentURLParser$KEY_NUMBER\.\(regex\|target\)" $TEMP_FILE > $FILE
+rm $TEMP_FILE
 
 echo "$TYPE_KEY=$TYPE_VALUE" >> $FILE
 echo "$REGEX_KEY=$REGEX_VALUE" >> $FILE

--- a/lib/win/sourcetree_add_commit_link_text.ps1
+++ b/lib/win/sourcetree_add_commit_link_text.ps1
@@ -1,0 +1,67 @@
+param([string]$file='.git\sourcetreeconfig')
+
+# Convert to a (possibly non-existent) absolute path, see
+# http://stackoverflow.com/a/3040982/1127485
+$fileAbs = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($file)
+
+$regex_InnerXML = git config --global bugtraq.jira.logregex
+$linkToUrl_InnerXML = (git config --global bugtraq.jira.url).replace('%BUGID%', '$1')
+
+if (Test-Path $file) {
+    Write-Host "Checking existing file '$file' for the LinkType element..."
+    $xmlData = [xml](Get-Content $file)
+    $linkType = $xmlData.SelectSingleNode('//RepositoryCustomSettings/CommitTextLinks/CommitTextLink/LinkType')
+
+    if ($linkType) {
+        Write-Host 'The LinkType element is already present and will not be modified.'
+    } else {
+        $repoCustomSettings = $xmlData.SelectSingleNode('//RepositoryCustomSettings')
+        if ($repoCustomSettings) {
+            function GetOrCreateNode($parentNode, $nodeName) {
+                $node = $parentNode.SelectSingleNode($nodeName)
+                if ($node) {
+                    Write-Host "Using existing '$nodeName' node."
+                    $node
+                } else {
+                    Write-Host "Creating new '$nodeName' node."
+                    $node = $parentNode.OwnerDocument.CreateElement($nodeName)
+                    $parentNode.AppendChild($node)
+                }
+            }
+
+            $commitTextLinks = GetOrCreateNode $repoCustomSettings 'CommitTextLinks'
+            $commitTextLink = GetOrCreateNode $commitTextLinks 'CommitTextLink'
+
+            $linkType = GetOrCreateNode $commitTextLink 'LinkType'
+            $linkType.set_InnerXML('Other')
+
+            $regex = GetOrCreateNode $commitTextLink 'Regex'
+            $regex.set_InnerXML($regex_InnerXML)
+
+            $linkToUrl = GetOrCreateNode $commitTextLink 'LinkToUrl'
+            $linkToUrl.set_InnerXML($linkToUrl_InnerXML)
+
+            $xmlData.Save($fileAbs)
+        } else {
+            Write-Host "Error: '$file' does not look like a valid SourceTree config file."
+        }
+    }
+} else {
+    Write-Host "Creating new file '$file' to add the LinkType element..."
+
+    $xmlData = @"
+<?xml version="1.0"?>
+<RepositoryCustomSettings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <CommitTextLinks>
+    <CommitTextLink>
+      <LinkType>Other</LinkType>
+      <Regex>$regex_InnerXML</Regex>
+      <LinkToUrl>$linkToUrl_InnerXML</LinkToUrl>
+    </CommitTextLink>
+  </CommitTextLinks>
+</RepositoryCustomSettings>
+"@
+
+    # Write the file UTF-8 encoded without BOM.
+    [IO.File]::WriteAllLines($fileAbs, $xmlData)
+}

--- a/lib/win/sourcetree_add_commit_link_text.ps1
+++ b/lib/win/sourcetree_add_commit_link_text.ps1
@@ -8,43 +8,43 @@ $regex_InnerXML = git config --global bugtraq.jira.logregex
 $linkToUrl_InnerXML = (git config --global bugtraq.jira.url).replace('%BUGID%', '$1')
 
 if (Test-Path $file) {
-    Write-Host "Checking existing file '$file' for the LinkType element..."
     $xmlData = [xml](Get-Content $file)
-    $linkType = $xmlData.SelectSingleNode('//RepositoryCustomSettings/CommitTextLinks/CommitTextLink/LinkType')
 
-    if ($linkType) {
-        Write-Host 'The LinkType element is already present and will not be modified.'
-    } else {
-        $repoCustomSettings = $xmlData.SelectSingleNode('//RepositoryCustomSettings')
-        if ($repoCustomSettings) {
-            function GetOrCreateNode($parentNode, $nodeName) {
-                $node = $parentNode.SelectSingleNode($nodeName)
-                if ($node) {
-                    Write-Host "Using existing '$nodeName' node."
-                    $node
-                } else {
-                    Write-Host "Creating new '$nodeName' node."
-                    $node = $parentNode.OwnerDocument.CreateElement($nodeName)
-                    $parentNode.AppendChild($node)
-                }
-            }
+    $repoCustomSettings = $xmlData.SelectSingleNode('//RepositoryCustomSettings')
+    if ($repoCustomSettings) {
+        function AppendNode($parentNode, $nodeName) {
+            $node = $parentNode.SelectSingleNode($nodeName)
 
-            $commitTextLinks = GetOrCreateNode $repoCustomSettings 'CommitTextLinks'
-            $commitTextLink = GetOrCreateNode $commitTextLinks 'CommitTextLink'
-
-            $linkType = GetOrCreateNode $commitTextLink 'LinkType'
-            $linkType.set_InnerXML('Other')
-
-            $regex = GetOrCreateNode $commitTextLink 'Regex'
-            $regex.set_InnerXML($regex_InnerXML)
-
-            $linkToUrl = GetOrCreateNode $commitTextLink 'LinkToUrl'
-            $linkToUrl.set_InnerXML($linkToUrl_InnerXML)
-
-            $xmlData.Save($fileAbs)
-        } else {
-            Write-Host "Error: '$file' does not look like a valid SourceTree config file."
+            Write-Host "Appending '$nodeName' node."
+            $node = $parentNode.OwnerDocument.CreateElement($nodeName)
+            $parentNode.AppendChild($node)
         }
+
+        function GetOrCreateNode($parentNode, $nodeName) {
+            $node = $parentNode.SelectSingleNode($nodeName)
+            if ($node) {
+                Write-Host "Using existing '$nodeName' node."
+                $node
+            } else {
+                AppendNode $parentNode $nodeName
+            }
+        }
+
+        $commitTextLinks = GetOrCreateNode $repoCustomSettings 'CommitTextLinks'
+        $commitTextLink = AppendNode $commitTextLinks 'CommitTextLink'
+
+        $linkType = GetOrCreateNode $commitTextLink 'LinkType'
+        $linkType.set_InnerXML('Other')
+
+        $regex = GetOrCreateNode $commitTextLink 'Regex'
+        $regex.set_InnerXML($regex_InnerXML)
+
+        $linkToUrl = GetOrCreateNode $commitTextLink 'LinkToUrl'
+        $linkToUrl.set_InnerXML($linkToUrl_InnerXML)
+
+        $xmlData.Save($fileAbs)
+    } else {
+        Write-Host "Error: '$file' does not look like a valid SourceTree config file."
     }
 } else {
     Write-Host "Creating new file '$file' to add the LinkType element..."


### PR DESCRIPTION
SourceTree uses its own `sourcetreeconfig` file inside the `.git` directory to store its settings. As these as are per-repository (and not global), we need to make the necessary changes after a repository has been created via `clone.sh`.

@larsxschneider This is largely untested as I'm neither using SourceTree on a regular basis, nor am I working on a Mac. But as I talked about this feature with you I wanted to deliver something :-) So please give it a try yourself before merging.