### PR TITLE
Add GITHUB_PROTOCOL support (http or https)

### DIFF
--- a/enterprise.constants
+++ b/enterprise.constants
@@ -9,6 +9,10 @@ KIT_ID='adsk'
 # Define your GitHub Enterprise server
 GITHUB_SERVER='git.yourcompany.com'
 
+
+# Add the protocol used to access GitHub server: http or https
+GITHUB_PROTOCOL='https'
+
 # Define the path of this repo on your GitHub Enterprise server
 KIT_ORG_REPO='yourorg/enterprise-config-for-git'
 
@@ -28,5 +32,6 @@ ERROR_HELP_MESSAGE="Please contact admin@yourcompany.com!"
 # No changes beyond this point
 ###############################################################################
 
-KIT_TESTFILE="https://$GITHUB_SERVER/raw/$KIT_ORG_REPO/master/README.md"
-KIT_REMOTE_URL="https://$GITHUB_SERVER/$KIT_ORG_REPO.git"
+GITHUB_URL="$GITHUB_PROTOCOL://$GITHUB_SERVER"
+KIT_TESTFILE="$GITHUB_URL/raw/$KIT_ORG_REPO/master/README.md"
+KIT_REMOTE_URL="$GITHUB_URL/$KIT_ORG_REPO.git"

--- a/help.sh
+++ b/help.sh
@@ -7,7 +7,7 @@ KIT_PATH=$(dirname "$0")
 
 # Infer a github url from a remote url
 INFO_URL=${KIT_REMOTE_URL%%.git}
-INFO_URL=${INFO_URL/#git@/https:\/\/}
+INFO_URL=${INFO_URL/#git@/$GITHUB_PROTOCOL:\/\/}
 
 read -r -d '\0' HELP <<EOM
 ###

--- a/lib/setup_helpers.sh
+++ b/lib/setup_helpers.sh
@@ -4,6 +4,11 @@
 VERSION_PARSER='use version; my ($version) = $_ =~ /([0-9]+([.][0-9]+)+)/; if (version->parse($version) lt version->parse($min)) { exit 1 };'
 CURL_RETRY_OPTIONS='--connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60'
 
+KIT_PATH=$(dirname "$0")
+. "$KIT_PATH/../enterprise.constants"
+
+PROTOCOL=$GITHUB_PROTOCOL
+
 function print_kit_header () {
     cat << EOM
 ###
@@ -33,16 +38,22 @@ function store_token () {
     local USER=$2
     local TOKEN="$3"
     local HELPER=$(credential_helper)
-    printf "protocol=https\nhost=$HOST\n\n" | git credential-$HELPER erase
-    printf "protocol=https\nhost=$HOST\nusername=$USER\npassword=${TOKEN/\%/\%\%}\n\n" | git credential-$HELPER store
+    printf "protocol=$PROTOCOL\nhost=$HOST\n\n" | git credential-$HELPER erase
+    printf "protocol=$PROTOCOL\nhost=$HOST\nusername=$USER\npassword=${TOKEN/\%/\%\%}\n\n" | git credential-$HELPER store
 }
 
 function get_credentials () {
     local HOST=$1
     local USER=$2
-    printf "protocol=https\nhost=$HOST\nusername=$USER\n\n" \
+    printf "protocol=$PROTOCOL\nhost=$HOST\nusername=$USER\n\n" \
         | git credential-$(credential_helper) get \
         | perl -0pe 's/.*password=//s'
+}
+
+function remove_credentials () {
+    local HOST=$1
+    local HELPER=$(credential_helper)
+    printf "protocol=$PROTOCOL\nhost=$HOST\n\n" | git credential-$HELPER erase
 }
 
 function has_command() {
@@ -64,7 +75,7 @@ function is_ghe_token_with_user_scope () {
     local HOST=$1
     local USER=$2
     local PASSWORD="$3"
-    curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" https://$HOST/api/v3/users -I \
+    curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" $PROTOCOL://$HOST/api/v3/users -I \
         | grep '^X-OAuth-Scopes:.*user.*' > /dev/null
 }
 
@@ -72,7 +83,7 @@ function get_ghe_name () {
     local HOST=$1
     local USER=$2
     local PASSWORD="$3"
-    curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" https://$HOST/api/v3/user \
+    curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" $PROTOCOL://$HOST/api/v3/user \
         | perl -ne 'print "$1" if m%^\s*"name":\s*"(.*)"[,]?$%i'
 }
 
@@ -80,7 +91,7 @@ function get_ghe_email () {
     local HOST=$1
     local USER=$2
     local PASSWORD="$3"
-    curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" https://$HOST/api/v3/user/emails \
+    curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" $PROTOCOL://$HOST/api/v3/user/emails \
         | perl -ne 'print "$1\n" if m%^\s*"email":\s*"(.*\@autodesk\.com)"[,]?$%i' \
         | head -n 1
 }
@@ -93,17 +104,17 @@ function create_ghe_token () {
     local CLIENT_SECRET=$5
     local COMPUTER_NAME=$(hostname)
     local FINGERPRINT=$(calc_md5sum "$COMPUTER_NAME")
-    local TOKEN_URL="https://$HOST/api/v3/authorizations/clients/$CLIENT_ID/$FINGERPRINT"
+    local TOKEN_URL="$PROTOCOL://$HOST/api/v3/authorizations/clients/$CLIENT_ID/$FINGERPRINT"
 
     # Query all tokens of the current user and try to find a token for the current machine
-    TOKEN_ID=$(curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" https://$HOST/api/v3/authorizations \
+    TOKEN_ID=$(curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" $PROTOCOL://$HOST/api/v3/authorizations \
         | perl -pe 'chomp' \
         | perl -sne 'print "$1\n" if m%^.*{\s*"id"\:\s+(\d+).*?"fingerprint":\s*"$fingerprint".*%i' -- -fingerprint=$FINGERPRINT \
     )
 
     # If a token for the current machine was found then delete it
     if [ -n $TOKEN_ID ]; then
-        curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" -X DELETE https://$HOST/api/v3/authorizations/$TOKEN_ID
+        curl $CURL_RETRY_OPTIONS --silent --fail --user "$USER:$PASSWORD" -X DELETE $PROTOCOL://$HOST/api/v3/authorizations/$TOKEN_ID
     fi
 
     # Request a new token
@@ -211,18 +222,18 @@ function rewrite_ssh_to_https_if_required () {
     # SSH exists with "1" in case the user successfully authenticated because
     # GitHub does not provide shell access.
     if [[ $SSH_EXIT -ne 1 ]]; then
-        echo "Configuring HTTPS URL rewrite for $HOST..."
+        echo "Configuring $PROTOCOL URL rewrite for $HOST..."
         set +e
-        git config --global --remove-section url."https://$HOST/" > /dev/null 2>&1
+        git config --global --remove-section url."$PROTOCOL://$HOST/" > /dev/null 2>&1
         set -e
-        git config --global --add url."https://$HOST/".insteadOf "ssh://git@$HOST:"
-        git config --global --add url."https://$HOST/".insteadOf "ssh://git@$HOST:/"
-        git config --global --add url."https://$HOST/".insteadOf "git@$HOST:"
-        git config --global --add url."https://$HOST/".insteadOf "git@$HOST:/"
-        git config --global --add url."https://$HOST/".pushInsteadOf "ssh://git@$HOST:"
-        git config --global --add url."https://$HOST/".pushInsteadOf "ssh://git@$HOST:/"
-        git config --global --add url."https://$HOST/".pushInsteadOf "git@$HOST:"
-        git config --global --add url."https://$HOST/".pushInsteadOf "git@$HOST:/"
+        git config --global --add url."$PROTOCOL://$HOST/".insteadOf "ssh://git@$HOST:"
+        git config --global --add url."$PROTOCOL://$HOST/".insteadOf "ssh://git@$HOST:/"
+        git config --global --add url."$PROTOCOL://$HOST/".insteadOf "git@$HOST:"
+        git config --global --add url."$PROTOCOL://$HOST/".insteadOf "git@$HOST:/"
+        git config --global --add url."$PROTOCOL://$HOST/".pushInsteadOf "ssh://git@$HOST:"
+        git config --global --add url."$PROTOCOL://$HOST/".pushInsteadOf "ssh://git@$HOST:/"
+        git config --global --add url."$PROTOCOL://$HOST/".pushInsteadOf "git@$HOST:"
+        git config --global --add url."$PROTOCOL://$HOST/".pushInsteadOf "git@$HOST:/"
     fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -42,9 +42,9 @@ if ! one_ping $GITHUB_SERVER > /dev/null 2>&1; then
     error_exit "Cannot reach $GITHUB_SERVER! Are you connected to the company network?"
 fi
 
-# Check if we can reach the GitHub Enterprise server via HTTPS
-if ! curl $CURL_RETRY_OPTIONS --silent --fail https://$GITHUB_SERVER > /dev/null 2>&1; then
-    error_exit "Cannot connect to $GITHUB_SERVER via HTTPS!"
+# Check if we can reach the GitHub Enterprise server
+if ! curl $CURL_RETRY_OPTIONS --silent --fail $GITHUB_URL > /dev/null 2>&1; then
+    error_exit "Cannot connect to $GITHUB_SERVER via $GITHUB_PROTOCOL!"
 fi
 
 if [[ -z $QUIET_INTRO ]]; then
@@ -194,9 +194,9 @@ if [[ -z $IS_SERVICE_ACCOUNT ]]; then
         EMAIL=$(get_ghe_email $GITHUB_SERVER $ADS_USER "$ADS_PASSWORD_OR_TOKEN")
 
         if [[ -z "$NAME" ]]; then
-            error_exit "Could not retrieve your name. Please go to https://$GITHUB_SERVER/settings/profile and check your name!"
+            error_exit "Could not retrieve your name. Please go to $GITHUB_URL/settings/profile and check your name!"
         elif [[ -z "$EMAIL" ]]; then
-            error_exit "Could not retrieve your email address. Please go to https://$GITHUB_SERVER/settings/emails and check your email!"
+            error_exit "Could not retrieve your email address. Please go to $GITHUB_URL/settings/emails and check your email!"
         fi
 
         echo ''

--- a/teardown.sh
+++ b/teardown.sh
@@ -9,12 +9,6 @@ set -e
 KIT_PATH=$(dirname "$0")
 . "$KIT_PATH/lib/setup_helpers.sh"
 
-function remove_credentials () {
-    local HOST=$1
-    local HELPER=$(credential_helper)
-    printf "protocol=https\nhost=$HOST\n\n" | git credential-$HELPER erase
-}
-
 remove_credentials '<< YOUR GITHUB SERVER >>>'
 
 print_kit_header


### PR DESCRIPTION
In my company the GitHub Enterprise server is (currently) running with http.
So I've tried to make this configurable by 2 new variables in enterprise.constants:
- GITHUB_PROTOCOL: default set to https
- GITHUB_URL: contains the protocol + server